### PR TITLE
fix negated 1bpp TIFs with Photometric.MINISBLACK

### DIFF
--- a/Pdf/PdfDictionaryExtensions.cs
+++ b/Pdf/PdfDictionaryExtensions.cs
@@ -175,6 +175,12 @@ namespace PdfSharp.Pdf
           for (int i = 0; i < imageData.Height; i++) {
             tiff.ReadScanline(buffer, i);
 
+            if (!ccittFaxDecodeParameters.BlackIs1) {
+              for (var j = 0; j < buffer.Length; j++) {
+                buffer[j] = (byte) (255 - buffer[j]);
+              }
+            }
+            
             Rectangle imgRect = new Rectangle(0, i, imageData.Width, 1);
             BitmapData imgData = bitmap.LockBits(imgRect, ImageLockMode.WriteOnly, PixelFormat.Format1bppIndexed);
             Marshal.Copy(buffer, 0, imgData.Scan0, buffer.Length);


### PR DESCRIPTION
TIF images with Photometric.MINISBLACK are being extracted with their colors negated (white is black and black is white).

I think this is because TIFs with the Photometric tag set to MINISBLACK have their image data negated and System.Drawing.Bitmap doesn't appear to allow setting this, so it displays the data as-is, which is negated.

The only way I've found to fix this is to negate the image data in ImageFromCCITTFaxDecode if CCITTFaxDecodeParameters.BlackIs1 is false.

This should fix the issues complaining about this problem - #6 and #8